### PR TITLE
feature/rym-11-local-storage-favorite-characters

### DIFF
--- a/src/components/CardCharacter/Card.tsx
+++ b/src/components/CardCharacter/Card.tsx
@@ -21,7 +21,6 @@ import {
 import { useNavigate } from "react-router-dom";
 import { useDispatch } from "react-redux";
 import { addFavoriteCharacter } from "../../redux/slices/character.slice";
-import React, { useEffect, useState } from "react";
 import { useAppSelector } from "../../redux/hooks";
 
 type CardProps = {
@@ -41,16 +40,12 @@ export const CardComponent: React.FC<CardProps> = ({
   gender,
   id,
 }) => {
-  const [disableBtn, setDisableBtn] = useState(false);
   const navigate = useNavigate();
   const matches = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
   const dispatch = useDispatch();
 
   const itemExist = useAppSelector((state) => state.favoriteReducer);
   /*Probé eliminarlo pero el botón quedaba en rojo  */
-  useEffect(() => {
-    setDisableBtn(itemExist.some((item) => item.id === id));
-  }, [itemExist, id]);
   const handleAddFavorite = () => {
     dispatch(addFavoriteCharacter({ id, name, info: status, image }));
   };
@@ -107,9 +102,18 @@ export const CardComponent: React.FC<CardProps> = ({
               )}
             </Box>
             <Box>
-              <Button onClick={handleAddFavorite} disabled={disableBtn}>
+              <Button
+                onClick={handleAddFavorite}
+                disabled={itemExist.some((item) => item.id === id)}
+              >
                 <Tooltip TransitionComponent={Zoom} title="Agregar a Favoritos">
-                  <FavoriteIcon color={disableBtn ? "error" : "action"} />
+                  <FavoriteIcon
+                    color={
+                      itemExist.some((item) => item.id === id)
+                        ? "error"
+                        : "action"
+                    }
+                  />
                 </Tooltip>
               </Button>
             </Box>

--- a/src/redux/slices/character.slice.ts
+++ b/src/redux/slices/character.slice.ts
@@ -13,7 +13,8 @@ interface RemoveFavoriteState {
 }
 
 // Define the initial state using that type
-const initialState: FavoriteState[] = [];
+const initialState: FavoriteState[] =
+  JSON.parse(localStorage.getItem("favoriteCharacters") ?? "") || [];
 
 export const favoriteCharacter = createSlice({
   name: "favorite",
@@ -28,8 +29,10 @@ export const favoriteCharacter = createSlice({
       ) {
         state.push(action.payload);
       }
+      // Guarda los datos en el localStorage después de actualizar el estado
+      localStorage.setItem("favoriteCharacters", JSON.stringify(state));
     },
-    removeFavoriteCharacter: (
+    /* removeFavoriteCharacter: (
       state,
       action: PayloadAction<RemoveFavoriteState>
     ) => {
@@ -38,6 +41,40 @@ export const favoriteCharacter = createSlice({
       if (state.some((item) => item.id === id)) {
         return (state = state.filter((item) => item.id !== id));
       }
+      // Guarda los datos en el localStorage después de actualizar el estado
+      localStorage.setItem("favoriteCharacters", JSON.stringify(state));
+    },
+       removeFavoriteCharacter: (
+      state,
+      action: PayloadAction<RemoveFavoriteState>
+    ) => {
+      const { id } = action.payload;
+      // Add logic to handle removing a favorite character
+      if (state.some((item) => item.id === id)) {
+        return state.filter((item, index) => {
+          if (item.id === id) {
+            // Remove the item from the state
+            state.splice(index, 1);
+          }
+        });
+      }
+      // Guarda los datos en el localStorage después de actualizar el estado
+      localStorage.setItem("favoriteCharacters", JSON.stringify(state));
+    },
+
+   
+   */
+    removeFavoriteCharacter: (
+      state,
+      action: PayloadAction<RemoveFavoriteState>
+    ) => {
+      const { id } = action.payload;
+      const index = state.findIndex((item) => item.id === id);
+      if (index !== -1) {
+        state.splice(index, 1);
+      }
+      // Guarda los datos en el localStorage después de actualizar el estado
+      localStorage.setItem("favoriteCharacters", JSON.stringify(state));
     },
   },
 });

--- a/src/redux/slices/character.slice.ts
+++ b/src/redux/slices/character.slice.ts
@@ -13,8 +13,9 @@ interface RemoveFavoriteState {
 }
 
 // Define the initial state using that type
-const initialState: FavoriteState[] =
-  JSON.parse(localStorage.getItem("favoriteCharacters") ?? "") || [];
+const initialState: FavoriteState[] = JSON.parse(
+  localStorage.getItem("favoriteCharacters") ?? "[]"
+);
 
 export const favoriteCharacter = createSlice({
   name: "favorite",

--- a/src/redux/slices/character.slice.ts
+++ b/src/redux/slices/character.slice.ts
@@ -13,8 +13,10 @@ interface RemoveFavoriteState {
 }
 
 // Define the initial state using that type
+const FAVORITE_CHARACTERS_KEY = "favoriteCharacters";
+
 const initialState: FavoriteState[] = JSON.parse(
-  localStorage.getItem("favoriteCharacters") ?? "[]"
+  localStorage.getItem(FAVORITE_CHARACTERS_KEY) ?? "[]"
 );
 
 export const favoriteCharacter = createSlice({
@@ -70,12 +72,13 @@ export const favoriteCharacter = createSlice({
       action: PayloadAction<RemoveFavoriteState>
     ) => {
       const { id } = action.payload;
-      const index = state.findIndex((item) => item.id === id);
-      if (index !== -1) {
-        state.splice(index, 1);
+      const iCharacter = state.findIndex((item) => item.id === id);
+      if (iCharacter !== -1) {
+        state.splice(iCharacter, 1);
       }
+
       // Guarda los datos en el localStorage después de actualizar el estado
-      localStorage.setItem("favoriteCharacters", JSON.stringify(state));
+      localStorage.setItem(FAVORITE_CHARACTERS_KEY, JSON.stringify(state));
     },
   },
 });


### PR DESCRIPTION
## Explicación del problema 

Anteriormente al actualizar la pagina, no se estaban guardando los personajes favoritos en el local storage 

### Issues Relacionados
RYM-11 
RYM-12

## Qué se hizo para solucionar el problema?
Se implementó la funcionalidad de LocalStorage en el archivo donde se maneja el redux


### Screenshots
![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/b033982d-c6fd-424f-95cd-2e8a971963a9)


![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/b673128d-3264-43de-9e4b-16c950bb0138)



## Cómo probar el cambio?

Agregar personajes a como favoritos y recargar la pagina. Comprobar que los que hayan sido agregados permanezcan y los que hayan sido eliminados no estén


