### PR TITLE
 feature/rym-10-add-internal-page-episode

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from "react-router-dom";
 import CharacterComponent from "./pages/characters/index";
 import RouterLayout from "./common/RouterLayout";
 import BasicTabs from "./pages/testTab";
+import EpisodeComponent from "./pages/internalEpisode";
 const AppRouter: React.FC = () => {
   return (
     <Routes>
@@ -10,6 +11,7 @@ const AppRouter: React.FC = () => {
         <Route path="/" element={<BasicTabs value={0} />} />
         <Route path="/characters/:id" element={<CharacterComponent />} />
         <Route path="/episodes" element={<BasicTabs value={1} />} />
+        <Route path="/episode/:id" element={<EpisodeComponent />} />
       </Route>
     </Routes>
   );

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -5,13 +5,18 @@ import RouterLayout from "./common/RouterLayout";
 import BasicTabs from "./pages/testTab";
 import EpisodeComponent from "./pages/internalEpisode";
 const AppRouter: React.FC = () => {
+  const ROUTES = {
+    ALL_EPISODES: "/episodes",
+    EPISODE: "/episode/:id",
+    CHARACTER_ID: "/characters/:id",
+  };
   return (
     <Routes>
       <Route path="/" element={<RouterLayout />}>
         <Route path="/" element={<BasicTabs value={0} />} />
-        <Route path="/characters/:id" element={<CharacterComponent />} />
-        <Route path="/episodes" element={<BasicTabs value={1} />} />
-        <Route path="/episode/:id" element={<EpisodeComponent />} />
+        <Route path={ROUTES.CHARACTER_ID} element={<CharacterComponent />} />
+        <Route path={ROUTES.ALL_EPISODES} element={<BasicTabs value={1} />} />
+        <Route path={ROUTES.EPISODE} element={<EpisodeComponent />} />
       </Route>
     </Routes>
   );

--- a/src/adapters/episodeAdapters.ts
+++ b/src/adapters/episodeAdapters.ts
@@ -1,0 +1,20 @@
+import { ICharacter } from "../pages/characters/interface/character.interface";
+import {
+  TypeEpisodeApi,
+  TypeEpisodeDOM,
+} from "./../pages/episodes/interface/index";
+
+export const episodeAdapter = (
+  episodeDataAPI: TypeEpisodeApi,
+  characters: ICharacter[]
+): TypeEpisodeDOM => {
+  return {
+    id: episodeDataAPI.id,
+    name: episodeDataAPI.name,
+    airDate: episodeDataAPI.air_date,
+    episode: episodeDataAPI.episode,
+    characters: characters,
+    url: episodeDataAPI.url,
+    created: episodeDataAPI.created,
+  };
+};

--- a/src/api/episode.ts
+++ b/src/api/episode.ts
@@ -1,3 +1,4 @@
+import { episodeAdapter } from "../adapters/episodeAdapters";
 import { ICharacter } from "../pages/characters/interface/character.interface";
 import { TypeEpisodeApi, TypeEpisodeDOM } from "../pages/episodes/interface";
 import { instance, BASE_URL } from "./base.api";
@@ -35,15 +36,12 @@ export const episodes = {
     const characters = await episodes.getCharactersByEpisode({
       ids: characterIds,
     });
-    const episodeDataDOM: TypeEpisodeDOM = {
-      id: episodeData.id,
-      name: episodeData.name,
-      airDate: episodeData.air_date,
-      episode: episodeData.episode,
-      characters: characters,
-      url: episodeData.url,
-      created: episodeData.created,
-    };
+
+    //Create adapter in episodeAdapters.ts
+    const episodeDataDOM: TypeEpisodeDOM = episodeAdapter(
+      episodeData,
+      characters
+    );
     return episodeDataDOM;
   },
 

--- a/src/api/episode.ts
+++ b/src/api/episode.ts
@@ -1,18 +1,23 @@
-import { instance } from "./base.api";
+import { ICharacter } from "../pages/characters/interface/character.interface";
+import { TypeEpisodeApi, TypeEpisodeDOM } from "../pages/episodes/interface";
+import { instance, BASE_URL } from "./base.api";
 
 const episode = "episode";
 export const episodes = {
   getEpisode: function ({
+    id,
     page,
     name,
     airdate,
   }: {
+    id?: number;
     page: number;
     name: string;
     airdate: string;
   }) {
     return instance.get(episode, {
       params: {
+        id,
         page,
         name,
         airdate,
@@ -20,7 +25,40 @@ export const episodes = {
     });
   },
 
-  getById: function ({ id }: { id: string | undefined }) {
-    return instance.get(`${episode}/${id}`);
+  getEpisodeById: async function ({ id }: { id: string | undefined }) {
+    const episodeData = (await instance.get(`${episode}/${id}`))
+      .data as TypeEpisodeApi;
+    const characterIds = episodeData.characters.map((url) => {
+      const urlParts = url.split("/");
+      return urlParts[urlParts.length - 1];
+    });
+    const characters = await episodes.getCharactersByEpisode({
+      ids: characterIds,
+    });
+    const episodeDataDOM: TypeEpisodeDOM = {
+      id: episodeData.id,
+      name: episodeData.name,
+      airDate: episodeData.air_date,
+      episode: episodeData.episode,
+      characters: characters,
+      url: episodeData.url,
+      created: episodeData.created,
+    };
+    return episodeDataDOM;
+  },
+
+  getCharactersByEpisode: async function ({ ids }: { ids: string[] }) {
+    try {
+      const res = await instance.get(createEndPoint({ ids }));
+      const characterDemo = res.data as ICharacter[];
+      return characterDemo;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
   },
 };
+
+function createEndPoint({ ids }: { ids: string[] }) {
+  return `${BASE_URL}/character/${ids.join(",")}`;
+}

--- a/src/components/CardEpisode/CardEpisode.tsx
+++ b/src/components/CardEpisode/CardEpisode.tsx
@@ -8,9 +8,10 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
-//import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type CardProps = {
+  id: number;
   name: string;
   airdate: string;
   episode: string;
@@ -18,11 +19,12 @@ type CardProps = {
 };
 
 export const CardEpisode: React.FC<CardProps> = ({
+  id,
   name,
   airdate,
   episode,
 }) => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const matches = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
   return (
     <Card sx={{ borderRadius: "20px" }}>
@@ -41,7 +43,7 @@ export const CardEpisode: React.FC<CardProps> = ({
       </CardContent>
       <CardActions>
         <Button
-          //  onClick={() => navigate(`/episode/${id}`)}
+          onClick={() => navigate(`/episode/${id}`)}
           fullWidth
           variant="contained"
           size="small"

--- a/src/pages/episodes/index.tsx
+++ b/src/pages/episodes/index.tsx
@@ -31,6 +31,7 @@ const Episodes = () => {
                 <Grid item xs={12} sm={6} md={4} lg={3} key={episodes.id}>
                   <CardEpisode
                     key={episodes.id}
+                    id={episodes.id}
                     name={episodes.name}
                     airdate={episodes.airDate}
                     episode={episodes.episode}

--- a/src/pages/episodes/interface/index.ts
+++ b/src/pages/episodes/interface/index.ts
@@ -1,9 +1,11 @@
+import { ICharacter } from "../../characters/interface/character.interface";
+
 export interface TypeEpisodeDOM {
   id: number;
   name: string;
   airDate: string;
   episode: string;
-  characters: string[];
+  characters: ICharacter[];
   url: string;
   created: Date;
 }

--- a/src/pages/internalEpisode/index.tsx
+++ b/src/pages/internalEpisode/index.tsx
@@ -1,0 +1,99 @@
+import { Box, CircularProgress, Container, Grid } from "@mui/material";
+import React from "react";
+import { useParams } from "react-router-dom";
+import { episodes } from "../../api/episode";
+import { TypeEpisodeDOM } from "../episodes/interface";
+import { CardComponent } from "../../components/CardCharacter/Card";
+
+const EpisodeComponent = () => {
+  const { id } = useParams();
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [episode, setEpisode] = React.useState<TypeEpisodeDOM | null>(null);
+
+  React.useEffect(() => {
+    setLoading(true);
+    episodes
+      .getEpisodeById({ id })
+      .then((data) => {
+        console.log(data);
+        setEpisode(data);
+        setTimeout(() => setLoading(false), 1000);
+      })
+      .catch((e) => console.log(e));
+  }, [id]);
+
+  return (
+    <Container
+      sx={{
+        width: "100vw !important",
+        height: "100vh",
+        paddingBottom: "100px",
+      }}
+    >
+      {loading ? (
+        <Box
+          sx={{
+            position: "absolute",
+            top: "50%",
+            left: "50%",
+            transform: "translate(-50%, -50%)",
+            display: "flex",
+            justifyContent: "center",
+          }}
+        >
+          <CircularProgress />
+        </Box>
+      ) : (
+        <Container
+          sx={{
+            marginTop: "100px",
+            marginBottom: "100px",
+            backgroundColor: "#1B4242",
+            padding: "50px 50px !important",
+            borderRadius: "10px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "100px",
+          }}
+          maxWidth="xl"
+        >
+          <Box sx={{ gap: "100px", display: "flex", flexDirection: "row" }}>
+            <Box sx={{ height: "auto " }}>
+              <h1>Información de Episodio</h1>
+            </Box>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "center",
+                alignContent: "center",
+                height: "auto ",
+              }}
+            >
+              <h1>{episode?.name}</h1>
+
+              <p>Episodio: {episode?.episode}</p>
+              <p>Fecha al aire: {episode?.airDate}</p>
+              <p style={{ fontWeight: "bold" }}> Apariciones:</p>
+            </Box>
+          </Box>
+          <Grid container spacing={5}>
+            {episode?.characters?.map((character) => (
+              <Grid item xs={12} sm={6} md={4} lg={4} key={character.id}>
+                <CardComponent
+                  name={character.name}
+                  image={character.image}
+                  gender={character.gender}
+                  species={character.species}
+                  status={character.status}
+                  id={character.id}
+                />
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      )}
+    </Container>
+  );
+};
+export default EpisodeComponent;

--- a/src/pages/internalEpisode/index.tsx
+++ b/src/pages/internalEpisode/index.tsx
@@ -1,5 +1,5 @@
 import { Box, CircularProgress, Container, Grid } from "@mui/material";
-import React from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { episodes } from "../../api/episode";
 import { TypeEpisodeDOM } from "../episodes/interface";
@@ -7,10 +7,10 @@ import { CardComponent } from "../../components/CardCharacter/Card";
 
 const EpisodeComponent = () => {
   const { id } = useParams();
-  const [loading, setLoading] = React.useState<boolean>(true);
-  const [episode, setEpisode] = React.useState<TypeEpisodeDOM | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [episode, setEpisode] = useState<TypeEpisodeDOM | null>(null);
 
-  React.useEffect(() => {
+  /* useEffect(() => {
     setLoading(true);
     episodes
       .getEpisodeById({ id })
@@ -20,6 +20,22 @@ const EpisodeComponent = () => {
         setTimeout(() => setLoading(false), 1000);
       })
       .catch((e) => console.log(e));
+  }, [id]);
+*/
+  //new form of useEffect
+  useEffect(() => {
+    const fetchEpisode = async () => {
+      try {
+        setLoading(true);
+        const data = await episodes.getEpisodeById({ id });
+        setEpisode(data);
+        setLoading(false), 1000;
+      } catch (e) {
+        console.log(e);
+      }
+    };
+
+    fetchEpisode();
   }, [id]);
 
   return (


### PR DESCRIPTION
## Explicación del problema

No había sido creada la página de información de cada episodios.

### Issues Relacionados
RYM-10
https://app.asana.com/0/1206613979557024/1206613979557003/f


## Qué se hizo para solucionar el problema?

Se creó la página interna con los requisitos solicitados


### Screenshots

Antes: 

![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/d53f6ea2-4b0c-41e3-9184-abb4f3692e6f)


Después: 

![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/69328ab7-6d65-4b57-a47a-889f9dc84066)


## Cómo probar el cambio?

Entrar  al tab de episodios y posterior a eso seleccionar el Botón de más información para entrar a la página interna de cada episodio 

![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/6ae08079-f840-4d22-8cc1-8f2985e97a1b)


