### PR TITLE
fix/rym-07-add-props-for-list-of-episodes

### DIFF
--- a/src/components/CardEpisode/CardEpisode.tsx
+++ b/src/components/CardEpisode/CardEpisode.tsx
@@ -8,9 +8,10 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
-//import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type CardProps = {
+  id: number;
   name: string;
   airdate: string;
   episode: string;
@@ -18,12 +19,14 @@ type CardProps = {
 };
 
 export const CardEpisode: React.FC<CardProps> = ({
+  id,
   name,
   airdate,
   episode,
 }) => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const matches = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
+  console.log("id", id);
   return (
     <Card sx={{ borderRadius: "20px" }}>
       <CardContent>
@@ -41,7 +44,7 @@ export const CardEpisode: React.FC<CardProps> = ({
       </CardContent>
       <CardActions>
         <Button
-          //  onClick={() => navigate(`/episode/${id}`)}
+          onClick={() => navigate(`/episode/${id}`)}
           fullWidth
           variant="contained"
           size="small"

--- a/src/pages/episodes/index.tsx
+++ b/src/pages/episodes/index.tsx
@@ -31,6 +31,7 @@ const Episodes = () => {
                 <Grid item xs={12} sm={6} md={4} lg={3} key={episodes.id}>
                   <CardEpisode
                     key={episodes.id}
+                    id={episodes.id}
                     name={episodes.name}
                     airdate={episodes.airDate}
                     episode={episodes.episode}


### PR DESCRIPTION
## Explicación del problema

Al dar click en el botón de más información no estaba redirigiendo a la página interna ni a la ruta 

### Issues Relacionados

RYM-07: https://app.asana.com/0/1206613979557024/1206613979556997/f

## Qué se hizo para solucionar el problema?

Se agregó la funcionalidad de rutas, algunas propiedades y una función a la hora de hacer click en el botón 

### Screenshots

![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/33e4e919-949c-480b-8aac-ceacd651f94a)


![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/56b25360-5336-4a9b-989e-39ccd43b1997)


