### PR TITLE
Feature/ryme 09 add styled card of episodes

### DIFF
--- a/src/components/CardEpisode/CardEpisode.tsx
+++ b/src/components/CardEpisode/CardEpisode.tsx
@@ -8,9 +8,10 @@ import {
   Typography,
   useMediaQuery,
 } from "@mui/material";
-//import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 type CardProps = {
+  id: number;
   name: string;
   airdate: string;
   episode: string;
@@ -18,12 +19,14 @@ type CardProps = {
 };
 
 export const CardEpisode: React.FC<CardProps> = ({
+  id,
   name,
   airdate,
   episode,
 }) => {
-  // const navigate = useNavigate();
+  const navigate = useNavigate();
   const matches = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
+  console.log("id", id);
   return (
     <Card sx={{ borderRadius: "20px" }}>
       <CardContent>
@@ -41,7 +44,7 @@ export const CardEpisode: React.FC<CardProps> = ({
       </CardContent>
       <CardActions>
         <Button
-          //  onClick={() => navigate(`/episode/${id}`)}
+          onClick={() => navigate(`/episode/${id}`)}
           fullWidth
           variant="contained"
           size="small"

--- a/src/components/CardEpisode/CardEpisode.tsx
+++ b/src/components/CardEpisode/CardEpisode.tsx
@@ -28,7 +28,16 @@ export const CardEpisode: React.FC<CardProps> = ({
   const matches = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
   console.log("id", id);
   return (
-    <Card sx={{ borderRadius: "20px" }}>
+    <Card
+      sx={{
+        borderRadius: "20px",
+        minHeight: "420px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        paddingBottom: "20px",
+      }}
+    >
       <CardContent>
         <Typography variant={matches ? "h5" : "h4"}>{name}</Typography>
         <Divider sx={{ mt: 2 }} />

--- a/src/pages/episodes/index.tsx
+++ b/src/pages/episodes/index.tsx
@@ -31,6 +31,7 @@ const Episodes = () => {
                 <Grid item xs={12} sm={6} md={4} lg={3} key={episodes.id}>
                   <CardEpisode
                     key={episodes.id}
+                    id={episodes.id}
                     name={episodes.name}
                     airdate={episodes.airDate}
                     episode={episodes.episode}


### PR DESCRIPTION
## Explicación del problema

No se había implementado el cambio de estilos para que las tarjetas de episodios fueran homogeneas

### Issues Relacionados
 RYM-07
https://app.asana.com/0/1206613979557024/1206613979556997/f
RYME-09
https://app.asana.com/0/0/1206668701145015/f


## Qué se hizo para solucionar el problema?

Se agregaron estilos de css en el componente Card en CardEpisode


### Screenshots


![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/e32a3640-94ca-42e9-bde1-aa714026605e)

## Cómo probar el cambio?

Entrar  al tab de episodios y ver que la información se muestre correctamente



