### PR TITLE
feature/ryme-09 add styled card of episodes

### DIFF
--- a/src/components/CardEpisode/CardEpisode.tsx
+++ b/src/components/CardEpisode/CardEpisode.tsx
@@ -28,7 +28,16 @@ export const CardEpisode: React.FC<CardProps> = ({
   const matches = useMediaQuery((theme: Theme) => theme.breakpoints.down("sm"));
   console.log("id", id);
   return (
-    <Card sx={{ borderRadius: "20px" }}>
+    <Card
+      sx={{
+        borderRadius: "20px",
+        minHeight: "420px",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        paddingBottom: "20px",
+      }}
+    >
       <CardContent>
         <Typography variant={matches ? "h5" : "h4"}>{name}</Typography>
         <Divider sx={{ mt: 2 }} />


### PR DESCRIPTION
## Explicación del problema

No se había implementado el cambio de estilos para que las tarjetas de episodios fueran homogeneas

### Issues Relacionados
 RYM-07
https://app.asana.com/0/1206613979557024/1206613979556997/f
RYME-09
https://app.asana.com/0/0/1206668701145015/f


## Qué se hizo para solucionar el problema?

Se agregaron estilos de css en el componente Card en CardEpisode


### Screenshots


![image](https://github.com/Ambrusecoding/rick-and-morty/assets/111497104/e32a3640-94ca-42e9-bde1-aa714026605e)

## Cómo probar el cambio?

Entrar  al tab de episodios y ver que la información se muestre correctamente



